### PR TITLE
[TD-478] Fix upgrade bug

### DIFF
--- a/wf-gen/goreleaser/nfpm.m4
+++ b/wf-gen/goreleaser/nfpm.m4
@@ -87,8 +87,8 @@ ifelse(xREPO, <<tyk-analytics>>,<<
 >>)dnl
     scripts:
       preinstall: "install/before_install.sh"
-      postinstall: "install/post_install.sh"
       postremove: "install/post_remove.sh"
+      postinstall: "install/post_install.sh"
     bindir: "/opt/xCOMPATIBILITY_NAME"
     overrides:
       rpm:
@@ -135,8 +135,8 @@ ifelse(xREPO, <<tyk-analytics>>, <<
         type: "config|noreplace"
     scripts:
       preinstall: "install/before_install.sh"
-      postinstall: "install/post_install.sh"
       postremove: "install/post_remove.sh"
+      postinstall: "install/post_install.sh"
     bindir: "/opt/xCOMPATIBILITY_NAME"
     rpm:
       signature:


### PR DESCRIPTION
Currently the process when you try to upgrade tyk to newer version is broken and service file gets removed after the upgrade. Reason for it is when the upgrade is happening we run first `post_install.sh` which adds the service file, but then we run `post_remove.sh` which removes it.

This PR is reversing this order, so we can remove the old package first and then install the new one.