### PR TITLE
fix(goreleaser): pass TYK_GW_TAG into the plugin compiler build args

### DIFF
--- a/wf-gen/goreleaser/docker.tyk.m4
+++ b/wf-gen/goreleaser/docker.tyk.m4
@@ -42,6 +42,7 @@
     - "tykio/tyk-plugin-compiler:v{{ .Major }}.{{ .Minor }}{{.Prerelease}}"
   build_flag_templates:
     - "--build-arg=branch={{ .Branch }}"
+    - "--build-arg=TYK_GW_TAG={{ .Tag }}"
     - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.title=tyk-plugin-compiler"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"


### PR DESCRIPTION
Missing build arg results in wrong Tyk Gateway being pulled into the plugin compiler's image.