### PR TITLE
Fix upgarde order

### DIFF
--- a/wf-gen/post_install.sh.m4
+++ b/wf-gen/post_install.sh.m4
@@ -86,8 +86,8 @@ case "$action" in
 	;;
     "2" | "upgrade")
 	printf "\033[32m Post Install of an upgrade\033[0m\n"
-       restoreSystemd
-       upgrade
+	restoreSystemd
+	upgrade
 	;;
     *)
 	# $1 == version being installed


### PR DESCRIPTION
The upgrade first tries to restart the service in the upgrade function and then it restores the systemd service in restoreSystemd function, which results in error when upgrading the debian packages.
To fix this we need to switch the order when doing an upgrade - first we should restoreSystemd and then do the upgrade.