### PR TITLE
Removes post-install systemd unit editing as it's incorrect and isn't needed

### DIFF
--- a/wf-gen/post_install.sh.m4
+++ b/wf-gen/post_install.sh.m4
@@ -56,12 +56,6 @@ cleanInstall() {
 
         service xCOMPATIBILITY_NAME restart ||:
     else
-        # rhel/centos7 cannot use ExecStartPre=+ to specify the pre start should be run as root
-        # even if you want your service to run as non root.
-        if [ "${systemd_version}" -lt 231 ]; then
-            printf "\033[31m systemd version %s is less then 231, fixing the service file \033[0m\n" "${systemd_version}"
-            sed -i "s/=+/=/g" $SYSTEMD/xCOMPATIBILITY_NAME.service
-        fi
         printf "\033[32m Reload the service unit from disk\033[0m\n"
         systemctl daemon-reload ||:
         printf "\033[32m Unmask the service\033[0m\n"


### PR DESCRIPTION
The path to the unit file is incorrect, which causes errors on clean install. It's not really needed in our case either, so removing it altogether.