### PR TITLE
Add matrix job for go1.15, go1.15-el7

### DIFF
--- a/wf-gen/goreleaser/cgo-builds.m4
+++ b/wf-gen/goreleaser/cgo-builds.m4
@@ -11,15 +11,7 @@ ifelse(xREPO, <<tyk>>, <<
       - linux
     goarch:
       - amd64
-  - id: std-darwin
-    ldflags:
-      - -X xPKG_NAME.VERSION={{.Version}} -X xPKG_NAME.commit={{.FullCommit}} -X xPKG_NAME.buildDate={{.Date}} -X xPKG_NAME.builtBy=goreleaser
-    env:
-      - CC=o64-clang
-    goos:
-      - darwin
-    goarch:
-      - amd64
+
   - id: std-arm64
 ifelse(xREPO, <<tyk>>, <<
     flags:

--- a/wf-gen/goreleaser/nfpm.m4
+++ b/wf-gen/goreleaser/nfpm.m4
@@ -5,6 +5,7 @@ nfpms:
     maintainer: "Tyk <info@tyk.io>"
     description: xPKG_DESC
     package_name: xCOMPATIBILITY_NAME
+    file_name_template: "{{ .PackageName }}-{{ .Env.GOLANG_CROSS }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     builds:
 ifelse(xCGO, <<1>>,<<
       - std-linux

--- a/wf-gen/release/goreleaser.m4
+++ b/wf-gen/release/goreleaser.m4
@@ -1,7 +1,14 @@
   goreleaser:
+    name: '${{ matrix.golang_cross }}'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        golang_cross: [1.15,1.15-el7]
+    env:
+      GOLANG_CROSS: ${{ matrix.golang_cross }}
 ifelse(xCGO, <<1>>, <<
-    container: tykio/golang-cross:1.15.15
+    container: 'tykio/golang-cross:${{ matrix.golang_cross }}'
 >>)
     outputs:
       tag: ${{ steps.targets.outputs.tag }}

--- a/wf-gen/release/packagecloud.m4
+++ b/wf-gen/release/packagecloud.m4
@@ -4,6 +4,10 @@
       - smoke-tests
       - goreleaser
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        golang_cross: [1.15, 1.15-el7]
 
     steps:
       - uses: actions/download-artifact@v2
@@ -24,6 +28,8 @@
         with:
           repo: tyk/${{ needs.goreleaser.outputs.pc }}
           dir: dist
+          rpmvers: ${{ matrix.golang_cross == '1.15-el7' && 'el/7' || 'el/8' }}
+          debvers: ${{ matrix.golang_cross == '1.15-el7' && "ubuntu/xenial debian/stretch" || "ubuntu/bionic ubuntu/focal debian/jessie" }}
 
       - name: Tell release channel
         if: always()


### PR DESCRIPTION
- Add matrix job for go1.15, go1.15-el7
- Remove darwin support
- Update filename format to have golang cross version in package name
- Provide target os versions on package cloud action