### PR TITLE
Change package_name string for PAYG

### DIFF
--- a/wf-gen/goreleaser/nfpm.m4
+++ b/wf-gen/goreleaser/nfpm.m4
@@ -98,7 +98,7 @@ ifelse(xREPO, <<tyk-analytics>>, <<
     homepage: "https://tyk.io"
     maintainer: "Tyk <info@tyk.io>"
     description: "PAYG Dashboard for the Tyk API Gateway"
-    package_name: xCOMPATIBILITY_NAME
+    package_name: xCOMPATIBILITY_NAME-PAYG
     file_name_template: "{{ .ProjectName }}_PAYG_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     builds:
       - payg


### PR DESCRIPTION
This will avoid PAYG packages overriding other debs and rpm packages