### PR TITLE
Remove setting repo variable in goreleaser step.

### DIFF
--- a/wf-gen/release/goreleaser.m4
+++ b/wf-gen/release/goreleaser.m4
@@ -115,7 +115,6 @@ ifelse(xREPO, <<tyk>>,
           GOLANG_CROSS: ${{ matrix.golang_cross }}
           DEBVERS: ${{ matrix.debvers }}
           RPMVERS: ${{ matrix.rpmvers }}
-          REPO: tyk/tyk-gateway-unstable
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
The variable to specify the repo to be pushed to is set in the publishers section of goreleaser config. 
https://github.com/TykTechnologies/tyk-ci/blob/30e58b826f1ab589faf7c34a850146eb00e914fb/wf-gen/goreleaser/publishers.m4#L5
So we can remove setting  this variable here, as it was not referenced anywhere anyway.