### PR TITLE
add tyk/tyk-plugin-compiler linux/arm64 image

### DIFF
--- a/wf-gen/goreleaser-el7.yml.m4
+++ b/wf-gen/goreleaser-el7.yml.m4
@@ -20,6 +20,16 @@ ifelse(xREPO, <<tyk>>,
 dockers:
 include(goreleaser/plugin-compiler.m4))
 
+docker_manifests:
+  - name_template: tykio/tyk-plugin-compiler:{{ .Tag }}xEL7_SUFFIX
+    image_templates:
+    - tykio/tyk-plugin-compiler:{{ .Tag }}xEL7_SUFFIX-amd64
+    - tykio/tyk-plugin-compiler:{{ .Tag }}xEL7_SUFFIX-arm64
+  - name_template: tykio/tyk-plugin-compiler:v{{ .Major }}.{{ .Minor }}{{.Prerelease}}xEL7_SUFFIX
+    image_templates:
+    - tykio/tyk-plugin-compiler:{{ .Tag }}xEL7_SUFFIX-amd64
+    - tykio/tyk-plugin-compiler:{{ .Tag }}xEL7_SUFFIX-arm64
+
 checksum:
   disable: true
 

--- a/wf-gen/goreleaser.yml.m4
+++ b/wf-gen/goreleaser.yml.m4
@@ -22,6 +22,17 @@ docker_manifests:
     - tykio/xDH_REPO:{{ .Tag }}-amd64
     - tykio/xDH_REPO:{{ .Tag }}-arm64
 ifelse(xREPO, <<tyk>>, <<
+docker_manifests:
+  - name_template: tykio/tyk-plugin-compiler:{{ .Tag }}xEL7_SUFFIX
+    image_templates:
+    - tykio/tyk-plugin-compiler:{{ .Tag }}xEL7_SUFFIX-amd64
+    - tykio/tyk-plugin-compiler:{{ .Tag }}xEL7_SUFFIX-arm64
+  - name_template: tykio/tyk-plugin-compiler:v{{ .Major }}.{{ .Minor }}{{.Prerelease}}xEL7_SUFFIX
+    image_templates:
+    - tykio/tyk-plugin-compiler:{{ .Tag }}xEL7_SUFFIX-amd64
+    - tykio/tyk-plugin-compiler:{{ .Tag }}xEL7_SUFFIX-arm64
+>>)
+ifelse(xREPO, <<tyk>>, <<
   - name_template: tykio/tyk-hybrid-docker:{{ .Tag }}
     image_templates:
     - tykio/tyk-hybrid-docker:{{ .Tag }}-amd64

--- a/wf-gen/goreleaser/plugin-compiler.m4
+++ b/wf-gen/goreleaser/plugin-compiler.m4
@@ -1,20 +1,64 @@
 dnl The default EL7 suffix is nil, it is set on the command line when needed
 define(xEL7_SUFFIX)dnl
 
-# Build plugin-compiler
+# Build plugin-compiler amd64
 - ids:
     - std
   image_templates:
-    - tykio/tyk-plugin-compiler:{{ .Tag }}xEL7_SUFFIX
-    - "tykio/tyk-plugin-compiler:v{{ .Major }}.{{ .Minor }}{{.Prerelease}}xEL7_SUFFIX"
+    - tykio/tyk-plugin-compiler:{{ .Tag }}xEL7_SUFFIX-amd64
   build_flag_templates:
+    - "--platform=linux/amd64"
     - "--label=org.opencontainers.image.created={{.Date}}"
-    - "--label=org.opencontainers.image.title=tyk-plugin-compiler"
+    - "--label=org.opencontainers.image.title=tyk-plugin-compiler-amd64"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
     - "--build-arg=TYK_GW_TAG={{ .Tag }}"
     - "--build-arg=GOLANG_CROSS={{ .Env.GOLANG_CROSS }}"
   goarch: amd64
+  goos: linux
+  dockerfile: ci/images/plugin-compiler/Dockerfile
+  extra_files:
+    - ci/images/plugin-compiler
+    - go.mod
+    - apidef
+    - certs
+    - checkup
+    - cli
+    - config
+    - coprocess
+    - ctx
+    - dlpython
+    - dnscache
+    - gateway
+    - goplugin
+    - headers
+    - log
+    - regexp
+    - request
+    - rpc
+    - signature_validator
+    - storage
+    - tcp
+    - templates
+    - test
+    - testdata
+    - trace
+    - user
+
+# Build plugin-compiler arm64
+- ids:
+    - std
+  image_templates:
+    - tykio/tyk-plugin-compiler:{{ .Tag }}xEL7_SUFFIX-arm64
+  build_flag_templates:
+    - "--platform=linux/arm64"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title=tyk-plugin-compiler-arm64"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--build-arg=TYK_GW_TAG={{ .Tag }}"
+    - "--build-arg=GOLANG_CROSS={{ .Env.GOLANG_CROSS }}"
+  goarch: arm64
   goos: linux
   dockerfile: ci/images/plugin-compiler/Dockerfile
   extra_files:


### PR DESCRIPTION
When running `tyk-demo` on Mac M1 we get missing linux/arm64/v8 image.

```
docker: Error response from daemon: image with reference tykio/tyk-plugin-compiler:v4.0.0 was found but does not match the specified platform: wanted linux/arm64/v8, actual: linux/amd64.
```

In order to fix this for everyone using `tyk-demo` on Mac M1 machines this PR adds building of linux/arm64 image.  