### PR TITLE
[TT-12894] Add Apache Kafka support to tyk-ci environment

### DIFF
--- a/auto/deps_pro.yml
+++ b/auto/deps_pro.yml
@@ -63,3 +63,22 @@ services:
       context: ./webhook-server
     ports:
       - "9003:9003"
+
+  kafka:
+    image: apache/kafka:3.8.0  # Replace with the desired Kafka version
+    container_name: kafka
+    ports:
+      - "9094:9094"
+    environment:
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_NODE_ID: 1
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      KAFKA_METADATA_LOG_DIR: /var/lib/kafka/data
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+    volumes:
+      - ./temp/kafka/data:/var/lib/kafka/data

--- a/auto/pro.yml
+++ b/auto/pro.yml
@@ -13,12 +13,13 @@ services:
       - "6000:6000"
       - "8003:8003"
       - "8080:8080"
-    entrypoint: ["/bin/bash"]
-    command:
-      - "-c"
-      - |
-        update-ca-certificates
-        /opt/tyk-gateway/tyk --conf /conf/tyk.conf
+    #entrypoint: ["/bin/bash"]
+    command: ["--conf", "/conf/tyk.conf"]
+    #command:
+    #  - "-c"
+    #  - |
+    #    update-ca-certificates
+    #    /opt/tyk-gateway/tyk --conf /conf/tyk.conf
 
   tyk-analytics:
     profiles: ["all", "master-datacenter"]
@@ -50,7 +51,7 @@ services:
       - "8061:8061"
     command: [ "--conf", "/conf/tyk-pump.conf" ]
     depends_on:
-      - wait_deps
+      - wait_db
 
   gateway-checker:
     profiles: ["all", "master-datacenter"]

--- a/auto/pro/tyk-analytics.conf
+++ b/auto/pro/tyk-analytics.conf
@@ -5,6 +5,9 @@
         "Port": "8080",
         "Secret": "352d20ee67be67f6340b4c0605b044b7"
     },
+    "streaming": {
+        "enabled": true
+    },
     "enable_ownership": true,
     "mongo_use_ssl": false,
     "mongo_ssl_insecure_skip_verify": false,

--- a/auto/pro/tyk.conf
+++ b/auto/pro/tyk.conf
@@ -13,6 +13,9 @@
         "policy_record_name": "tyk_policies",
         "allow_explicit_policy_id": true
     },
+    "streaming": {
+        "enabled": true
+    },
     "use_db_app_configs": true,
     "db_app_conf_options": {
         "connection_string": "http://tyk-analytics:3000",


### PR DESCRIPTION
This PR adds Apache Kafka support to tyk-ci environment. It's a required dependency for Tyk Streams integration test suite. 

Related PR: https://github.com/TykTechnologies/tyk-analytics/pull/4181

I had to disable `entrypoint` instruction for Tyk GW container because the image doesn't include any shell. 

See the related issue: https://tyktech.atlassian.net/browse/TT-12894