### PR TITLE
TT-16130: Add DependencyTrack playground deployment

### DIFF
--- a/deptrack-playground/alb.tf
+++ b/deptrack-playground/alb.tf
@@ -1,0 +1,117 @@
+# Application Load Balancer
+
+resource "aws_lb" "deptrack" {
+  name               = local.name_prefix
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = local.subnet_ids
+
+  enable_deletion_protection = false # Set to true for production
+
+  access_logs {
+    bucket  = local.alb_logs_bucket
+    prefix  = "alb"
+    enabled = var.create_s3_bucket
+  }
+
+  tags = {
+    Name = local.name_prefix
+  }
+}
+
+# HTTP Listener (redirects to HTTPS when certificate is available)
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.deptrack.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.frontend.arn
+  }
+}
+
+# Target Groups
+resource "aws_lb_target_group" "frontend" {
+  name        = "${local.name_prefix}-fe"
+  port        = local.dtrack_port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = local.vpc_id
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    path                = "/"
+    protocol            = "HTTP"
+    matcher             = "200-399"
+  }
+
+  deregistration_delay = 30
+
+  tags = {
+    Name = "${local.name_prefix}-fe"
+  }
+}
+
+resource "aws_lb_target_group" "api" {
+  name        = "${local.name_prefix}-api"
+  port        = local.dtrack_port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = local.vpc_id
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    path                = "/api/version"
+    protocol            = "HTTP"
+    matcher             = "200"
+  }
+
+  deregistration_delay = 30
+
+  tags = {
+    Name = "${local.name_prefix}-api"
+  }
+}
+
+# Listener rules for routing
+resource "aws_lb_listener_rule" "frontend" {
+  listener_arn = aws_lb_listener.http.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.frontend.arn
+  }
+
+  condition {
+    host_header {
+      values = ["deptrack.tyk.io"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "api" {
+  listener_arn = aws_lb_listener.http.arn
+  priority     = 200
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api.arn
+  }
+
+  condition {
+    host_header {
+      values = ["api.deptrack.tyk.io"]
+    }
+  }
+}

--- a/deptrack-playground/ecs.tf
+++ b/deptrack-playground/ecs.tf
@@ -1,0 +1,39 @@
+# ECS Cluster and CloudWatch Logs
+
+resource "aws_ecs_cluster" "deptrack" {
+  name = local.name_prefix
+
+  configuration {
+    execute_command_configuration {
+      logging = "OVERRIDE"
+      log_configuration {
+        cloud_watch_log_group_name = aws_cloudwatch_log_group.deptrack.name
+      }
+    }
+  }
+
+  tags = {
+    Name = local.name_prefix
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "deptrack" {
+  cluster_name = aws_ecs_cluster.deptrack.name
+
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+    base              = 1
+  }
+}
+
+resource "aws_cloudwatch_log_group" "deptrack" {
+  name              = "/ecs/${local.name_prefix}"
+  retention_in_days = 7
+
+  tags = {
+    Name = "${local.name_prefix}-logs"
+  }
+}

--- a/deptrack-playground/ecs_services.tf
+++ b/deptrack-playground/ecs_services.tf
@@ -1,0 +1,244 @@
+# ECS Task Definitions and Services
+
+# Placeholder for deptrack database password in SSM
+# This will be created manually after RDS is provisioned
+# IMPORTANT: Uncomment this after creating the SSM parameter
+# data "aws_ssm_parameter" "deptrack_db_pass" {
+#   name            = "/${local.name_prefix}/db_pass"
+#   with_decryption = false
+# }
+
+# Temporary placeholder - replace with actual SSM parameter ARN after creation
+locals {
+  deptrack_db_pass_arn = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${local.name_prefix}/db_pass"
+}
+
+# API Server Task Definition
+resource "aws_ecs_task_definition" "api" {
+  family                   = "${local.name_prefix}-api"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 4096
+  memory                   = 16384
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  volume {
+    name = "deptrack-data"
+
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.deptrack.id
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = aws_efs_access_point.deptrack.id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = "api"
+      image     = "dependencytrack/apiserver:${local.dtrack_version}"
+      essential = true
+      cpu       = 4096
+      memory    = 16384
+      memoryReservation = 8192
+
+      mountPoints = [
+        {
+          sourceVolume  = "deptrack-data"
+          containerPath = "/data"
+          readOnly      = false
+        }
+      ]
+
+      portMappings = [
+        {
+          containerPort = local.dtrack_port
+          protocol      = "tcp"
+          name          = "api"
+        }
+      ]
+
+      environment = [
+        { name = "ALPINE_DATABASE_MODE", value = "external" },
+        { name = "ALPINE_DATABASE_URL", value = "jdbc:postgresql://${aws_db_instance.deptrack.address}:${aws_db_instance.deptrack.port}/${local.dtrack_db_name}?sslmode=require&sslfactory=org.postgresql.ssl.NonValidatingFactory" },
+        { name = "ALPINE_DATABASE_DRIVER", value = "org.postgresql.Driver" },
+        { name = "ALPINE_DATABASE_USERNAME", value = local.dtrack_db_user },
+        { name = "ALPINE_DATABASE_POOL_ENABLED", value = "true" },
+        { name = "ALPINE_DATABASE_POOL_MAX_SIZE", value = "20" },
+        { name = "ALPINE_DATABASE_POOL_MIN_IDLE", value = "10" },
+        { name = "ALPINE_DATABASE_POOL_IDLE_TIMEOUT", value = "300000" },
+        { name = "ALPINE_DATABASE_POOL_MAX_LIFETIME", value = "600000" },
+        { name = "ALPINE_CORS_ENABLED", value = "true" },
+        { name = "ALPINE_CORS_ALLOW_ORIGIN", value = "*" },
+        { name = "ALPINE_CORS_ALLOW_METHODS", value = "GET,POST,PUT,DELETE,OPTIONS" },
+        { name = "ALPINE_CORS_ALLOW_HEADERS", value = "Origin, Content-Type, Authorization, X-Requested-With, Content-Length, Accept, Origin, X-Api-Key, X-Total-Count, *" },
+        { name = "ALPINE_CORS_EXPOSE_HEADERS", value = "Origin, Content-Type, Authorization, X-Requested-With, Content-Length, Accept, Origin, X-Api-Key, X-Total-Count" },
+        { name = "ALPINE_CORS_ALLOW_CREDENTIALS", value = "true" },
+        # OIDC Configuration - Commented out to enable local admin login
+        # Uncomment these lines and redeploy to enable OneLogin SSO
+        # { name = "ALPINE_OIDC_ENABLED", value = "true" },
+        # { name = "ALPINE_OIDC_ISSUER", value = "https://tyk.onelogin.com/oidc/2" },
+        # { name = "ALPINE_OIDC_CLIENT_ID", value = "511adce0-c1b0-013b-ebc1-06a565e566d1150043" },
+        # { name = "ALPINE_OIDC_USERNAME_CLAIM", value = "preferred_username" },
+        # { name = "ALPINE_OIDC_TEAMS_CLAIM", value = "groups" },
+        # { name = "ALPINE_OIDC_USER_PROVISIONING", value = "true" },
+        # { name = "ALPINE_OIDC_TEAM_SYNCHRONIZATION", value = "false" },
+        { name = "LOGGING_LEVEL", value = "INFO" }
+      ]
+
+      secrets = [
+        {
+          name      = "ALPINE_DATABASE_PASSWORD"
+          valueFrom = local.deptrack_db_pass_arn
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.deptrack.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "api"
+        }
+      }
+
+      healthCheck = {
+        command     = ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:${local.dtrack_port}/api/version || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 120
+      }
+    }
+  ])
+
+  tags = {
+    Name = "${local.name_prefix}-api"
+  }
+}
+
+# API Server Service
+resource "aws_ecs_service" "api" {
+  name            = "${local.name_prefix}-api"
+  cluster         = aws_ecs_cluster.deptrack.id
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = var.api_task_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = local.subnet_ids
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api.arn
+    container_name   = "api"
+    container_port   = local.dtrack_port
+  }
+
+  enable_execute_command = true
+
+  depends_on = [
+    aws_lb_listener.http,
+    aws_efs_mount_target.deptrack
+  ]
+
+  tags = {
+    Name = "${local.name_prefix}-api"
+  }
+}
+
+# Frontend Task Definition
+resource "aws_ecs_task_definition" "frontend" {
+  family                   = "${local.name_prefix}-frontend"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 512
+  memory                   = 1024
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "frontend"
+      image     = "dependencytrack/frontend:${local.dtrack_version}"
+      essential = true
+      cpu       = 512
+      memory    = 1024
+
+      portMappings = [
+        {
+          containerPort = local.dtrack_port
+          protocol      = "tcp"
+          name          = "frontend"
+        }
+      ]
+
+      environment = [
+        { name = "API_BASE_URL", value = "http://api.deptrack.tyk.io" }
+        # OIDC Configuration - Commented out to enable local admin login
+        # Uncomment these lines and redeploy to enable OneLogin SSO button
+        # { name = "OIDC_ISSUER", value = "https://tyk.onelogin.com/oidc/2" },
+        # { name = "OIDC_CLIENT_ID", value = "511adce0-c1b0-013b-ebc1-06a565e566d1150043" },
+        # { name = "OIDC_LOGIN_BUTTON_TEXT", value = "OneLogin" }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.deptrack.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "frontend"
+        }
+      }
+
+      healthCheck = {
+        command     = ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:${local.dtrack_port}/ || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 60
+      }
+    }
+  ])
+
+  tags = {
+    Name = "${local.name_prefix}-frontend"
+  }
+}
+
+# Frontend Service
+resource "aws_ecs_service" "frontend" {
+  name            = "${local.name_prefix}-frontend"
+  cluster         = aws_ecs_cluster.deptrack.id
+  task_definition = aws_ecs_task_definition.frontend.arn
+  desired_count   = var.frontend_task_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = local.subnet_ids
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.frontend.arn
+    container_name   = "frontend"
+    container_port   = local.dtrack_port
+  }
+
+  enable_execute_command = true
+
+  depends_on = [
+    aws_lb_listener.http,
+    aws_ecs_service.api
+  ]
+
+  tags = {
+    Name = "${local.name_prefix}-frontend"
+  }
+}

--- a/deptrack-playground/efs.tf
+++ b/deptrack-playground/efs.tf
@@ -1,0 +1,50 @@
+# EFS File System for DependencyTrack persistent storage
+
+resource "aws_efs_file_system" "deptrack" {
+  creation_token = "${local.name_prefix}-efs"
+  encrypted      = true
+  kms_key_id     = aws_kms_key.deptrack.arn
+
+  performance_mode = "generalPurpose"
+  throughput_mode  = "bursting"
+
+  lifecycle_policy {
+    transition_to_ia = "AFTER_30_DAYS"
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-efs"
+  }
+}
+
+# Create mount targets in all subnets
+resource "aws_efs_mount_target" "deptrack" {
+  count = length(local.subnet_ids)
+
+  file_system_id  = aws_efs_file_system.deptrack.id
+  subnet_id       = local.subnet_ids[count.index]
+  security_groups = [aws_security_group.efs.id]
+}
+
+# Access point for DependencyTrack
+resource "aws_efs_access_point" "deptrack" {
+  file_system_id = aws_efs_file_system.deptrack.id
+
+  posix_user {
+    gid = 1000
+    uid = 1000
+  }
+
+  root_directory {
+    path = "/deptrack"
+    creation_info {
+      owner_gid   = 1000
+      owner_uid   = 1000
+      permissions = "755"
+    }
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-access-point"
+  }
+}

--- a/deptrack-playground/iam.tf
+++ b/deptrack-playground/iam.tf
@@ -1,0 +1,123 @@
+# IAM Roles for ECS Tasks
+
+# ECS Task Execution Role (for pulling images and writing logs)
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "${local.name_prefix}-ecs-task-execution"
+  path = "/ecs/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Name = "${local.name_prefix}-ecs-task-execution"
+  }
+}
+
+# Attach AWS managed policy for ECS task execution
+resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Custom policy for accessing SSM parameters and KMS
+resource "aws_iam_role_policy" "ecs_task_execution_custom" {
+  name = "ssm-kms-access"
+  role = aws_iam_role.ecs_task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "KMSDecrypt"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:DescribeKey"
+        ]
+        Resource = aws_kms_key.deptrack.arn
+      },
+      {
+        Sid    = "SSMGetParameters"
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameters",
+          "ssm:GetParameter"
+        ]
+        Resource = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${local.name_prefix}/*"
+      },
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# ECS Task Role (for application permissions)
+resource "aws_iam_role" "ecs_task" {
+  name = "${local.name_prefix}-ecs-task"
+  path = "/ecs/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Name = "${local.name_prefix}-ecs-task"
+  }
+}
+
+# Task role policy for CloudWatch and ECS Exec
+resource "aws_iam_role_policy" "ecs_task" {
+  name = "ecs-task-permissions"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "CloudWatchMetrics"
+        Effect = "Allow"
+        Action = [
+          "cloudwatch:PutMetricData"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "ECSExec"
+        Effect = "Allow"
+        Action = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/deptrack-playground/kms.tf
+++ b/deptrack-playground/kms.tf
@@ -1,0 +1,11 @@
+# KMS Key for encrypting SSM parameters
+resource "aws_kms_key" "deptrack" {
+  description             = "KMS key for DependencyTrack SSM parameter encryption"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_alias" "deptrack" {
+  name          = "alias/${local.name_prefix}-ssm"
+  target_key_id = aws_kms_key.deptrack.key_id
+}

--- a/deptrack-playground/main.tf
+++ b/deptrack-playground/main.tf
@@ -1,0 +1,55 @@
+# DependencyTrack Standalone Deployment for Playground Account
+# Account: 863518456494 (Tyk Playground: Persistent)
+# Region: eu-central-1
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+
+  default_tags {
+    tags = {
+      managed     = "terraform"
+      environment = "playground"
+      purpose     = "security"
+      project     = "deptrack"
+    }
+  }
+}
+
+locals {
+  name_prefix    = "deptrack-pg"
+  dtrack_port    = 8080
+  dtrack_version = "4.13.6"
+  dtrack_db_name = "deptrack"
+  dtrack_db_user = "deptrack"
+  
+  # Use existing default VPC
+  vpc_id = var.vpc_id
+  subnet_ids = var.subnet_ids
+}
+
+# Data source for existing VPC
+data "aws_vpc" "selected" {
+  id = local.vpc_id
+}
+
+data "aws_subnets" "selected" {
+  filter {
+    name   = "subnet-id"
+    values = local.subnet_ids
+  }
+}

--- a/deptrack-playground/outputs.tf
+++ b/deptrack-playground/outputs.tf
@@ -1,0 +1,91 @@
+# Outputs
+
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer"
+  value       = aws_lb.deptrack.dns_name
+}
+
+output "alb_url" {
+  description = "URL to access DependencyTrack (via ALB DNS)"
+  value       = "http://${aws_lb.deptrack.dns_name}"
+}
+
+output "api_url" {
+  description = "API endpoint URL (via ALB DNS)"
+  value       = "http://${aws_lb.deptrack.dns_name}/api"
+}
+
+output "custom_dns_frontend" {
+  description = "Frontend URL with custom DNS (configure CNAME in Cloudflare)"
+  value       = "http://deptrack.tyk.io"
+}
+
+output "custom_dns_api" {
+  description = "API URL with custom DNS (configure CNAME in Cloudflare)"
+  value       = "http://api.deptrack.tyk.io"
+}
+
+output "cloudflare_dns_records" {
+  description = "DNS records to create in Cloudflare"
+  value = {
+    frontend = {
+      name   = "deptrack.tyk.io"
+      type   = "CNAME"
+      target = aws_lb.deptrack.dns_name
+    }
+    api = {
+      name   = "api.deptrack.tyk.io"
+      type   = "CNAME"
+      target = aws_lb.deptrack.dns_name
+    }
+  }
+}
+
+output "rds_endpoint" {
+  description = "RDS database endpoint"
+  value       = aws_db_instance.deptrack.endpoint
+}
+
+output "rds_address" {
+  description = "RDS database address"
+  value       = aws_db_instance.deptrack.address
+}
+
+output "rds_port" {
+  description = "RDS database port"
+  value       = aws_db_instance.deptrack.port
+}
+
+output "efs_id" {
+  description = "EFS file system ID"
+  value       = aws_efs_file_system.deptrack.id
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name"
+  value       = aws_ecs_cluster.deptrack.name
+}
+
+output "kms_key_id" {
+  description = "KMS key ID for SSM parameters"
+  value       = aws_kms_key.deptrack.id
+}
+
+output "ssm_parameter_names" {
+  description = "SSM parameter names that need to be created/configured"
+  value = {
+    master_password = aws_ssm_parameter.db_master_password.name
+    db_password     = "/${local.name_prefix}/db_pass"
+  }
+}
+
+output "database_connection_info" {
+  description = "Database connection information for manual setup"
+  value = {
+    host     = aws_db_instance.deptrack.address
+    port     = aws_db_instance.deptrack.port
+    database = local.dtrack_db_name
+    username = local.dtrack_db_user
+    master_user = "master"
+  }
+}

--- a/deptrack-playground/rds.tf
+++ b/deptrack-playground/rds.tf
@@ -1,0 +1,67 @@
+# RDS PostgreSQL Database
+
+# Generate random password for RDS master user if not provided
+resource "random_password" "db_master" {
+  count   = var.db_master_password == "" ? 1 : 0
+  length  = 32
+  special = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "aws_db_subnet_group" "deptrack" {
+  name       = "${local.name_prefix}-db-subnet"
+  subnet_ids = local.subnet_ids
+
+  tags = {
+    Name = "${local.name_prefix}-db-subnet"
+  }
+}
+
+resource "aws_db_instance" "deptrack" {
+  identifier     = "${local.name_prefix}-db"
+  engine         = "postgres"
+  engine_version = "16.11"
+  instance_class = "db.t3.micro"
+
+  allocated_storage     = 20
+  max_allocated_storage = 100
+  storage_type          = "gp3"
+  storage_encrypted     = true
+
+  db_name  = local.dtrack_db_name
+  username = "master"
+  password = var.db_master_password != "" ? var.db_master_password : random_password.db_master[0].result
+
+  db_subnet_group_name   = aws_db_subnet_group.deptrack.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  publicly_accessible    = false
+
+  backup_retention_period = 7
+  backup_window          = "03:00-04:00"
+  maintenance_window     = "sun:04:00-sun:05:00"
+
+  skip_final_snapshot       = false
+  final_snapshot_identifier = "${local.name_prefix}-final-snapshot-${formatdate("YYYY-MM-DD-hhmm", timestamp())}"
+
+  deletion_protection = false # Set to true for production
+  multi_az           = false  # Set to true for production
+
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+
+  tags = {
+    Name = "${local.name_prefix}-db"
+  }
+}
+
+# Store the master password in SSM for reference
+resource "aws_ssm_parameter" "db_master_password" {
+  name        = "/${local.name_prefix}/db_master_pass"
+  description = "Master password for DependencyTrack RDS database"
+  type        = "SecureString"
+  value       = var.db_master_password != "" ? var.db_master_password : random_password.db_master[0].result
+  key_id      = aws_kms_key.deptrack.id
+
+  tags = {
+    Name = "${local.name_prefix}-db-master-pass"
+  }
+}

--- a/deptrack-playground/s3.tf
+++ b/deptrack-playground/s3.tf
@@ -1,0 +1,70 @@
+# S3 Bucket for ALB logs
+resource "aws_s3_bucket" "alb_logs" {
+  count  = var.create_s3_bucket ? 1 : 0
+  bucket = "${local.name_prefix}-alb-logs-${data.aws_caller_identity.current.account_id}"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "alb_logs" {
+  count  = var.create_s3_bucket ? 1 : 0
+  bucket = aws_s3_bucket.alb_logs[0].id
+
+  rule {
+    id     = "delete-old-logs"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = 90
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "alb_logs" {
+  count  = var.create_s3_bucket ? 1 : 0
+  bucket = aws_s3_bucket.alb_logs[0].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Allow ALB to write logs
+resource "aws_s3_bucket_policy" "alb_logs" {
+  count  = var.create_s3_bucket ? 1 : 0
+  bucket = aws_s3_bucket.alb_logs[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::054676820928:root"
+        }
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.alb_logs[0].arn}/*"
+      },
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "logging.s3.amazonaws.com"
+        }
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.alb_logs[0].arn}/*"
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  alb_logs_bucket = var.create_s3_bucket ? aws_s3_bucket.alb_logs[0].id : var.existing_s3_bucket
+}

--- a/deptrack-playground/security_groups.tf
+++ b/deptrack-playground/security_groups.tf
@@ -1,0 +1,141 @@
+# Security Groups
+
+# Security group for ALB
+resource "aws_security_group" "alb" {
+  name        = "${local.name_prefix}-alb"
+  description = "Security group for DependencyTrack ALB"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    description = "HTTP from anywhere"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS from anywhere"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-alb"
+  }
+}
+
+# Security group for ECS tasks
+resource "aws_security_group" "ecs_tasks" {
+  name        = "${local.name_prefix}-ecs-tasks"
+  description = "Security group for DependencyTrack ECS tasks"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    description     = "Application port from ALB"
+    from_port       = local.dtrack_port
+    to_port         = local.dtrack_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  ingress {
+    description = "Application port from VPC"
+    from_port   = local.dtrack_port
+    to_port     = local.dtrack_port
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.selected.cidr_block]
+  }
+
+  ingress {
+    description = "EFS from VPC"
+    from_port   = 2049
+    to_port     = 2049
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.selected.cidr_block]
+  }
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-ecs-tasks"
+  }
+}
+
+# Security group for RDS
+resource "aws_security_group" "rds" {
+  name        = "${local.name_prefix}-rds"
+  description = "Security group for DependencyTrack RDS"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    description     = "PostgreSQL from ECS tasks"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_tasks.id]
+  }
+
+  ingress {
+    description = "PostgreSQL from VPC (for bastion access from other account)"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.selected.cidr_block]
+  }
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-rds"
+  }
+}
+
+# Security group for EFS
+resource "aws_security_group" "efs" {
+  name        = "${local.name_prefix}-efs"
+  description = "Security group for DependencyTrack EFS"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    description     = "NFS from ECS tasks"
+    from_port       = 2049
+    to_port         = 2049
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_tasks.id]
+  }
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-efs"
+  }
+}

--- a/deptrack-playground/variables.tf
+++ b/deptrack-playground/variables.tf
@@ -1,0 +1,65 @@
+variable "aws_region" {
+  description = "AWS region for deployment"
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "aws_profile" {
+  description = "AWS CLI profile to use"
+  type        = string
+  default     = "863518456494_AdministratorAccess"
+}
+
+variable "vpc_id" {
+  description = "VPC ID to use for deployment"
+  type        = string
+  default     = "vpc-0cc4cd92338453905"
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs for deployment"
+  type        = list(string)
+  default = [
+    "subnet-07e6cada0b69ec28a", # eu-central-1a
+    "subnet-0aec1e4d3c9289d89", # eu-central-1c
+    "subnet-0daed39c422ca8267"  # eu-central-1b
+  ]
+}
+
+variable "db_master_password" {
+  description = "Master password for RDS database (will be auto-generated if not provided)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "deptrack_db_password" {
+  description = "Password for deptrack database user"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "create_s3_bucket" {
+  description = "Whether to create a new S3 bucket for ALB logs or use existing"
+  type        = bool
+  default     = true
+}
+
+variable "existing_s3_bucket" {
+  description = "Existing S3 bucket name for ALB logs (if create_s3_bucket is false)"
+  type        = string
+  default     = ""
+}
+
+variable "frontend_task_count" {
+  description = "Number of frontend tasks to run"
+  type        = number
+  default     = 1
+}
+
+variable "api_task_count" {
+  description = "Number of API server tasks to run"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
- Deploy DependencyTrack v4.13.6 to playground AWS account
- Configure host-based ALB routing (deptrack.tyk.io / api.deptrack.tyk.io)
- Set up RDS PostgreSQL 16.11 database
- Configure ECS Fargate services (API + Frontend)
- Add EFS for persistent storage
- Disable OIDC for local admin login
- Configure KMS encryption for secrets